### PR TITLE
Improve tests

### DIFF
--- a/action.ts
+++ b/action.ts
@@ -23,6 +23,9 @@ function message(msg: string) {
     message,
     messages,
     limit: 100,
+    branchName: `notfoundbot-${new Date()
+      .toLocaleDateString()
+      .replace(/\//g, "-")}`,
     stats: {
       cacheSkipped: 0,
       upgradedSSL: 0,

--- a/index.ts
+++ b/index.ts
@@ -14,4 +14,5 @@ export async function action(ctx: LContext) {
   await checkArchives(urlGroups);
   const updatedFiles = updateFiles(ctx, urlGroups);
   await suggestChanges(ctx, updatedFiles);
+  return updatedFiles;
 }

--- a/src/suggest_changes.ts
+++ b/src/suggest_changes.ts
@@ -2,13 +2,10 @@ import { LFile, LContext } from "../types";
 import { commitFile } from "./commit_file";
 
 async function createBranch(
-  { context, toolkit }: LContext,
+  { branchName, context, toolkit }: LContext,
   defaultBranch: string
 ) {
-  const branch = `notfoundbot-${new Date()
-    .toLocaleDateString()
-    .replace(/\//g, "-")}`;
-  const ref = `refs/heads/${branch}`;
+  const ref = `refs/heads/${branchName}`;
 
   const {
     data: {
@@ -26,7 +23,7 @@ async function createBranch(
     sha,
   });
 
-  return branch;
+  return branchName;
 }
 
 export async function getDefaultBranch({ toolkit, context }: LContext) {
@@ -81,10 +78,10 @@ export async function suggestChanges(ctx: LContext, updatedFiles: LFile[]) {
 
   ctx.message(`Suggesting changes`);
   const base = await getDefaultBranch(ctx);
-  const branch = await createBranch(ctx, base);
+  await createBranch(ctx, base);
 
   for (let file of updatedFiles) {
-    await commitFile(ctx, branch, file);
+    await commitFile(ctx, ctx.branchName, file);
   }
 
   const {
@@ -93,7 +90,7 @@ export async function suggestChanges(ctx: LContext, updatedFiles: LFile[]) {
     ...context.repo,
     title: getTitle(ctx),
     body: getBody(ctx),
-    head: branch,
+    head: ctx.branchName,
     base,
   });
 

--- a/test/action.ts
+++ b/test/action.ts
@@ -1,13 +1,64 @@
 import Nock from "nock";
+import Fs from "fs";
+import Path from "path";
 import { test } from "tap";
 import { action } from "../index";
 import { testContext } from "./helpers";
 
-test("action", async (_t) => {
+test("action", async (t) => {
   Nock("https://api.github.com")
     .persist()
     .get("/repos/foo/bar/issues?labels=notfoundbot")
     .reply(200, []);
 
-  await action(testContext());
+  Nock("https://api.github.com")
+    .persist()
+    .get("/repos/foo/bar")
+    .reply(200, { default_branch: "main" });
+
+  Nock("https://api.github.com")
+    .persist()
+    .get("/repos/foo/bar/git/ref/heads%2Fmain")
+    .reply(200, { object: { sha: "deadbeef" } });
+
+  Nock("https://api.github.com")
+    .persist()
+    .post("/repos/foo/bar/git/refs")
+    .reply(200, {});
+
+  Nock("https://api.github.com")
+    .persist()
+    .get(
+      "/repos/foo/bar/contents/_posts%2F2020-01-01-example.md?ref=refs%2Fheads%2Fnotfoundbot-12-31-2020"
+    )
+    .reply(200, { sha: "abcd" });
+
+  Nock("https://api.github.com")
+    .persist()
+    .put("/repos/foo/bar/contents/_posts%2F2020-01-01-example.md")
+    .reply(200, {});
+
+  Nock("https://api.github.com")
+    .persist()
+    .post("/repos/foo/bar/pulls")
+    .reply(200, {});
+
+  Nock("https://api.github.com")
+    .persist()
+    .post("/repos/foo/bar/issues//labels")
+    .reply(200, {});
+
+  Nock("https://google.com").persist().get("/").reply(200, []);
+  Nock("https://yahoo.com").persist().get("/").reply(200, []);
+  Nock("https://foo.com").persist().get("/").reply(200, []);
+
+  const ctx = testContext();
+
+  const gitPath = "_posts/2020-01-01-example.md";
+  const dest = Path.join(ctx.cwd, gitPath);
+  Fs.copyFileSync(Path.join(__dirname, "./fixtures/example.md"), dest);
+
+  const updatedFiles = await action(ctx);
+  t.same(ctx.messages[0], "1 files detected");
+  t.same(updatedFiles.length, 1);
 });

--- a/test/action.ts
+++ b/test/action.ts
@@ -29,7 +29,7 @@ test("action", async (t) => {
   Nock("https://api.github.com")
     .persist()
     .get(
-      "/repos/foo/bar/contents/_posts%2F2020-01-01-example.md?ref=refs%2Fheads%2Fnotfoundbot-12-31-2020"
+      "/repos/foo/bar/contents/_posts%2F2020-01-01-example.md?ref=refs%2Fheads%2Ftest-branch"
     )
     .reply(200, { sha: "abcd" });
 

--- a/test/check_links.ts
+++ b/test/check_links.ts
@@ -29,8 +29,8 @@ test("sniff - not found", async (t) => {
 });
 
 test("sniff - redirect to https", async (t) => {
+  Nock("https://macwright.com").persist().get("/").reply(200, []);
   t.equal((await sniff("http://macwright.com")).status, "upgrade");
-  t.equal((await sniff("http://jamesbridle.com")).status, "upgrade");
 });
 
 test("sniff - error", async (t) => {
@@ -38,6 +38,9 @@ test("sniff - error", async (t) => {
 });
 
 test("checkLinks", async (t) => {
+  Nock("http://google.com").persist().get("/").reply(200, []);
+  Nock("https://yahoo.com").persist().get("/").reply(200, []);
+  Nock("http://foo.com").persist().get("/").reply(200, []);
   const ctx = testContext();
   const groups = getTestFiles(ctx);
   await checkLinks(ctx, groups);

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -34,6 +34,7 @@ export function testContext(): LContext {
     message,
     messages,
     cache: {},
+    branchName: "test-branch",
     stats: {
       cacheSkipped: 0,
       upgradedSSL: 0,

--- a/test/ia_client.ts
+++ b/test/ia_client.ts
@@ -1,3 +1,4 @@
+import Nock from "nock";
 import { test } from "tap";
 import { queryIA, formatDate } from "../src/query_ia";
 import { testContext, getTestFiles } from "./helpers";
@@ -8,6 +9,10 @@ test("formatDate", async (t) => {
 
 test("queryIA with no groups", async (t) => {
   const ctx = testContext();
+
+  Nock("https://archive.org")
+    .post("/wayback/available")
+    .reply(200, { results: [1, 2, 3] });
 
   const groups = getTestFiles(ctx);
   t.same((await queryIA(groups)).results.length, 3);

--- a/test/util.ts
+++ b/test/util.ts
@@ -13,8 +13,3 @@ test("updateFiles", async (t) => {
   const updates = updateFiles(ctx, getTestFiles(ctx));
   t.same(updates.length, 0);
 });
-
-// test("replaceLinks", async (t) => {
-//   replaceLinks(lFile, "http://google.com", "https://google.com");
-//   t.same(lFile.replacements, ["http://google.com → https://google.com"]);
-// });

--- a/types.ts
+++ b/types.ts
@@ -44,6 +44,7 @@ export type LContext = {
   message: (message: string) => void;
   messages: string[];
   limit: number;
+  branchName: string;
   stats: {
     cacheSkipped: number;
     upgradedSSL: number;


### PR DESCRIPTION
This makes two changes to the test suite:

- Mocks _all_ HTTP/HTTPS traffic when testing. Tests should now work
  offline.
- Adds an example file to the action integration test. This makes it go
  through the whole flow and call all the GitHub-related code.