### PR TITLE
Allow duplicate keys in YAML

### DIFF
--- a/src/to_lfile.ts
+++ b/src/to_lfile.ts
@@ -15,8 +15,11 @@ const remark = Remark().use(frontmatter, ["yaml", "toml"]);
 export function frontmatterDate(ast: Node) {
   const node = select("yaml,toml", ast) as YamlNode | TomlNode;
   if (!node) return;
+  // Jekyll allows duplicate keys in YAML, but js-yaml will,
+  // by default, throw if it encounters one. The json: true
+  // option changes its behavior to take the last key value.
   const parsed = (node.type === "yaml"
-    ? yaml.safeLoad(node.value)
+    ? yaml.safeLoad(node.value, { json: true })
     : TOML.parse(node.value)) as any;
   if (!(typeof parsed.date === "string")) return;
   const date = new Date(parsed.date);

--- a/test/fixtures/example.md
+++ b/test/fixtures/example.md
@@ -1,5 +1,7 @@
 ---
 title: Test
+x: 2
+x: 3
 ---
 
 - [link](http://google.com/)


### PR DESCRIPTION
This fixes an issue encountered here: https://github.com/agrc/gis.utah.gov/commit/7c2122aed0cb05272e4572c4d4a26ba761b6c6e5/checks?check_suite_id=1750971095

Jekyll allows duplicate keys in YAML, but js-yaml does not, by default. This flips an option in js-yaml to support duplicate keys, and adds a duplicate key to example.md to validate this fix.