### PR TITLE
fix: Remove newline generated by remark.stringify

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -1,24 +1,33 @@
 import Remark from "remark";
 import { selectAll } from "unist-util-select";
 import type { Link } from "mdast";
+import MagicString from "magic-string";
 import frontmatter from "remark-frontmatter";
 import { LFile, LURLGroup, LContext } from "../types";
 
 const remark = Remark().use(frontmatter, ["yaml", "toml"]);
 
+function stringify(link: Link) {
+  return remark.stringify(link).replace(/\n$/, "");
+}
+
+function replaceLink(link: Link, magicString: MagicString, to: string) {
+  link.url = to;
+  magicString.overwrite(
+    link.position!.start.offset!,
+    link.position!.end.offset!,
+    stringify(link)
+  );
+}
+
 export function replaceLinks(file: LFile, a: string, b: string) {
   const { ast, magicString } = file;
   const links = selectAll("link", ast) as Link[];
-  for (let link of links) {
-    if (link.url === a) {
-      link.url = b;
-      magicString.overwrite(
-        link.position!.start.offset!,
-        link.position!.end.offset!,
-        remark.stringify(link)
-      );
-    }
-  }
+  links
+    .filter((link) => link.url === a)
+    .forEach((link) => {
+      replaceLink(link, magicString, b);
+    });
   file.replacements.push(`${a} → ${b}`);
 }
 

--- a/test/util.ts
+++ b/test/util.ts
@@ -13,3 +13,23 @@ test("updateFiles", async (t) => {
   const updates = updateFiles(ctx, getTestFiles(ctx));
   t.same(updates.length, 0);
 });
+
+test("replaceLinks", async (t) => {
+  const ctx = testContext();
+  const groups = getTestFiles(ctx);
+  const file = Array.from(groups[0].files)[0];
+  replaceLinks(file, "http://google.com/", "http://test.com/");
+  t.same(
+    file.magicString.toString(),
+    `---
+title: Test
+x: 2
+x: 3
+---
+
+- [link](http://test.com/)
+- [other link](http://foo.com/)
+- [https link](https://yahoo.com/)
+`
+  );
+});


### PR DESCRIPTION
Fixes #40. The root cause is that remark-stringify intentionally adds a newline to its output, for the ease of CLI and other code. That's not what we want here, so I'll remove it manually

https://github.com/syntax-tree/mdast-util-to-markdown/blob/f355cc6489517397a3ce6625975695058acaa69d/lib/index.js#L45

Includes a test to pin this behavior.