### PR TITLE
Upgrade internet archive relinks from http to https

### DIFF
--- a/src/check_archives.ts
+++ b/src/check_archives.ts
@@ -12,7 +12,7 @@ export async function checkArchives(groups: LURLGroup[]) {
     if (result.archived_snapshots?.closest?.available) {
       errorGroups.find((group) => group.url == result.url)!.status = {
         status: "archive",
-        to: result.archived_snapshots!.closest.url,
+        to: result.archived_snapshots!.closest.url.replace(/^http:/, "https:"),
       };
     }
   }

--- a/test/check_archives.ts
+++ b/test/check_archives.ts
@@ -19,7 +19,7 @@ test("checkArchives - found", async (t) => {
         tag: "0",
         archived_snapshots: {
           closest: {
-            url: "https://archived.com/google",
+            url: "http://archive.org/http://google.com/",
             status: "ok",
             timestamp: "1",
             available: true,
@@ -33,7 +33,7 @@ test("checkArchives - found", async (t) => {
   await checkArchives(groups);
   t.same(groups[0].status, {
     status: "archive",
-    to: "https://archived.com/google",
+    to: "https://archive.org/http://google.com/",
   });
 });
 


### PR DESCRIPTION
Fixes #49 - corrects the URLs returned by the Internet Archive API to use SSL, and adds a test to pin that fix.