### PR TITLE
fix: Allow websites to have untrusted SSL certificates for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "release": "standard-version",
     "build": "ncc build action.ts --license licenses.txt",
     "test": "tsc && tap test",
+    "cli": "ts-node ./cli.ts",
     "start": "./dist/index.js"
   },
   "bin": {

--- a/src/check_links.ts
+++ b/src/check_links.ts
@@ -78,6 +78,11 @@ async function sniffHttps(url: string): Promise<LStatus> {
       status: "ok",
     };
   } catch (err) {
+    if (err?.code === "UNABLE_TO_VERIFY_LEAF_SIGNATURE") {
+      return {
+        status: "ok",
+      };
+    }
     return {
       status: "error",
     };

--- a/test/check_links.ts
+++ b/test/check_links.ts
@@ -23,6 +23,13 @@ test("sniff - ok", async (t) => {
   t.equal((await sniff("https://a.com/")).status, "ok");
 });
 
+test("sniff - leaf cert failed ignored and ok", async (t) => {
+  Nock("https://a.com")
+    .get("/")
+    .replyWithError({ code: "UNABLE_TO_VERIFY_LEAF_SIGNATURE" });
+  t.equal((await sniff("https://a.com/")).status, "ok");
+});
+
 test("sniff - not found", async (t) => {
   Nock("https://a.com").get("/").reply(400, "ok");
   t.equal((await sniff("https://a.com/")).status, "error");


### PR DESCRIPTION
Refs #52 - this simply allows websites to have SSL certs from now-unreputable SSL providers. The alternatives are discussed in that issue - disable SSL checking entirely, or load up custom SSL certs. This is the middle of the road solution, a pragmatic one, I think, but I would be happy to accept refinements.